### PR TITLE
Consumables and highscore update

### DIFF
--- a/src/controller/GameLogic.java
+++ b/src/controller/GameLogic.java
@@ -27,6 +27,7 @@ public class GameLogic {
     private Timer timer;
     private int answerIndex;
     private boolean inMainMenu;
+    private boolean passed;
 
     private String status = "";
 
@@ -366,6 +367,25 @@ public class GameLogic {
         else if(counter.getAnsweredAmount() < 35) {
             counter.setGrade("F");
         }
+        if(counter.getAnsweredAmount() >= 35) {
+            passed = true;
+        }
+
+        String name = getPlayer().getName() + " - ";
+        String grade = getCounter().getGrade() + " - ";
+        String amount = String.valueOf(getCounter().getAnsweredAmount()) + "/70";
+        getHighscoreList().addHighscore(name + grade + amount);
+    }
+
+    /**
+     * Returns the final grade as a string.
+     * @return result
+     */
+    public String getFinalGrade() {
+        String result = player.getName() + " - " +
+                counter.getGrade() + " - " + counter.getAnsweredAmount() + "/70";
+
+        return result;
     }
 
     /**
@@ -537,5 +557,21 @@ public class GameLogic {
      */
     public void setInMainMenu(boolean inMainMenu) {
         this.inMainMenu = inMainMenu;
+    }
+
+    /**
+     * Returns the passed boolean.
+     * @return passed
+     */
+    public boolean isPassed() {
+        return passed;
+    }
+
+    /**
+     * Sets the passed boolean.
+     * @param passed
+     */
+    public void setPassed(boolean passed) {
+        this.passed = passed;
     }
 }

--- a/src/controller/GameLogic.java
+++ b/src/controller/GameLogic.java
@@ -161,7 +161,7 @@ public class GameLogic {
                     int newHealth = currHealth - player.getDamageDealt();
                     levelCreator.getLevel(counter.getLevel()).getEnemy().setHealth(newHealth);
                     mainFrame.getEnemyHealthBar().updateEnemyHealth();
-                    counter.setAnsweredAmount(counter.getAnsweredAmount()+1);
+                    counter.setAnsweredAmount(counter.getAnsweredAmount() + player.getDamageDealt());
                     status = "correct";
                     startFight(counter.getLevel());
                 }
@@ -170,14 +170,14 @@ public class GameLogic {
                     status = "";
                     timer.stopTimer();
                     mainFrame.getTextArea().setText(sceneChanger.getEnemyLines().get(counter.getLevel() - 1));
-                    addGold();
 
-                    counter.setAnsweredAmount(counter.getAnsweredAmount()+1);
+                    addGold();
                     hideComponents();
 
                     mainFrame.getTextArea().setForeground(Color.WHITE);
                     //Resets the damage dealt to 1 in case a damage potion was active before.
                     player.setDamageDealt(1);
+                    counter.setAnsweredAmount(counter.getAnsweredAmount() + player.getDamageDealt());
                     playerActions.setUsedPotion(false);
 
                     showShopPrompt();

--- a/src/controller/handlersAndActions/ActionHandler.java
+++ b/src/controller/handlersAndActions/ActionHandler.java
@@ -137,6 +137,7 @@ public class ActionHandler implements ActionListener, KeyListener {
                     controller.getMainFrame().getSceneCreator().getImageInPanel(i).setOpaque(false);
                     controller.getMainFrame().getSceneCreator().getImageInPanel(i).setVisible(false);
                 }
+                controller.getPlayer().restoreHealth();
                 controller.getEventPortal().enterPortal();
                 controller.getMainFrame().getFinalScenePanel().scoreAttributes();
                 break;

--- a/src/controller/handlersAndActions/ActionHandler.java
+++ b/src/controller/handlersAndActions/ActionHandler.java
@@ -98,6 +98,7 @@ public class ActionHandler implements ActionListener, KeyListener {
                 controller.getSceneChanger().showScene(controller.getCounter().getCurrentScene());
                 controller.getMusicPlayer().setGameOverActive(false);
                 controller.getMusicPlayer().startMusic();
+                controller.getCounter().resetGrade();
                 break;
             case "continue":
                 controller.getSceneChanger().showScene(controller.getCounter().getCurrentScene());
@@ -137,6 +138,7 @@ public class ActionHandler implements ActionListener, KeyListener {
                     controller.getMainFrame().getSceneCreator().getImageInPanel(i).setVisible(false);
                 }
                 controller.getEventPortal().enterPortal();
+                controller.getMainFrame().getFinalScenePanel().scoreAttributes();
                 break;
             case "returnMenu":
                 controller.getSceneChanger().exitFinalScene();
@@ -145,6 +147,7 @@ public class ActionHandler implements ActionListener, KeyListener {
                 controller.getMainFrame().getMainMenu().getPnlDiff().setVisible(false);
                 controller.getMainFrame().getFinalScenePanel().getPnlButtons().setVisible(false);
                 controller.getMainFrame().getMainMenu().getPnlProfiles().setVisible(false);
+                controller.getCounter().resetGrade();
                 break;
             case "backHighscore":
                 controller.getMainFrame().getMainMenu().getPnlHighscore().setVisible(false);
@@ -215,6 +218,7 @@ public class ActionHandler implements ActionListener, KeyListener {
                     controller.getMainFrame().getMainMenu().getPnlDiff().setVisible(false);
                 }
                 controller.getMainFrame().getMainMenu().getPnlButtons().setVisible(true);
+                controller.getCounter().resetGrade();
                 break;
             case "selectProfile":
                 if (playerIndex >= 0) {
@@ -269,6 +273,7 @@ public class ActionHandler implements ActionListener, KeyListener {
                             controller.getMainFrame().getMainMenu().getPnlProfiles().setVisible(false);
                             controller.getMainFrame().getMainMenu().getPnlDiff().setVisible(false);
                             controller.getMainFrame().getMainMenu().getPnlButtons().setVisible(true);
+                            controller.getCounter().resetGrade();
                         }
                     }
                     else {

--- a/src/controller/handlersAndActions/PlayerActions.java
+++ b/src/controller/handlersAndActions/PlayerActions.java
@@ -2,6 +2,8 @@ package controller.handlersAndActions;
 
 import controller.GameLogic;
 
+import javax.swing.*;
+
 /**
  * @author Mahmoud Daabas
  * @author Annie Tran
@@ -28,7 +30,7 @@ public class PlayerActions {
      */
     public void drinkDamagePotion() {
         controller.getShopItems().getDmgPot().setPotionActive(true);
-        if (controller.getShopItems().getDmgPot().getPotionActive() && !usedPotion) {
+        if (controller.getShopItems().getDmgPot().getPotionActive() && !usedPotion && !inShop && !controller.getPlayer().isOutOfCombat()) {
             controller.getMusicPlayer().playSoundEffects("resources/soundtracks/activateEquipmentSound.wav");
             controller.getPlayer().setDamageDealt(controller.getShopItems().getDmgPot().getDamageBoost());
             controller.getShopItems().setDamagePotionLimit(0);
@@ -37,6 +39,9 @@ public class PlayerActions {
             controller.getMainFrame().getBtnDamagePotion().setVisible(false);
             controller.getMainFrame().getLabelsAndStatus().getLblPotionStatus().setVisible(true);
         }
+        else if(controller.getPlayer().isOutOfCombat()){
+            JOptionPane.showMessageDialog(null, "You are not in combat!");
+        }
     }
 
     /**
@@ -44,17 +49,20 @@ public class PlayerActions {
      */
     public void equipShield() {
         controller.getShopItems().getShield().setEquipped(true);
-        if (controller.getShopItems().getShield().getIsEquipped() && !usedShield) {
+        if (controller.getShopItems().getShield().getIsEquipped() && !usedShield && !inShop && !controller.getPlayer().isOutOfCombat()) {
             controller.getMusicPlayer().playSoundEffects("resources/soundtracks/activateEquipmentSound.wav");
             controller.getShopItems().setShieldLimit(0);
             usedShield = true;
             controller.getMainFrame().getBtnShield().setVisible(false);
             controller.getMainFrame().getLabelsAndStatus().getShieldStatus().setVisible(true);
         }
+        else if(controller.getPlayer().isOutOfCombat()){
+            JOptionPane.showMessageDialog(null, "You are not in combat!");
+        }
     }
 
     public void useHint() {
-        if(!usedHint && !inShop) {
+        if(!usedHint && !inShop && !controller.getPlayer().isOutOfCombat()) {
             try {
                 controller.getMusicPlayer().playSoundEffects("resources/soundtracks/activateEquipmentSound.wav");
                 int buttonToDisable = controller.getMathQuestion().getCorrectAnswerIndex()+1;
@@ -70,6 +78,9 @@ public class PlayerActions {
                 usedHint = true;
                 controller.getMainFrame().getBtnHint().setVisible(false);
             }
+        }
+        else if(controller.getPlayer().isOutOfCombat()){
+            JOptionPane.showMessageDialog(null, "You are not in combat!");
         }
     }
 

--- a/src/model/Counter.java
+++ b/src/model/Counter.java
@@ -36,6 +36,14 @@ public class Counter {
     }
 
     /**
+     * Resets the grade after it has been applied.
+     */
+    public void resetGrade() {
+        grade = "";
+        answeredAmount = 0;
+    }
+
+    /**
      * Constructor that initializes the controller.
      * @param controller GameLogic-object used to initialize own GameLogic-object
      */

--- a/src/view/MainFrame.java
+++ b/src/view/MainFrame.java
@@ -73,7 +73,7 @@ public class MainFrame extends JFrame {
         objectCreator.createObjects();
 
         shopPanels = new ShopPanels(controller, this, action);
-        finalScenePanel = new FinalScenePanel(this, action);
+        finalScenePanel = new FinalScenePanel(this, action, controller);
 
         portalCreator = new PortalCreator(this, controller, action);
         portalCreator.createTP();
@@ -165,6 +165,7 @@ public class MainFrame extends JFrame {
         btnMainMenu.setFocusPainted(false);
         btnMainMenu.setBackground(null);
         btnMainMenu.setBorderPainted(false);
+        btnMainMenu.setFocusable(false);
 
         btnMainMenu.setForeground(Color.WHITE);
         add(btnMainMenu);

--- a/src/view/SceneChanger.java
+++ b/src/view/SceneChanger.java
@@ -194,6 +194,8 @@ public class SceneChanger {
         controller.getPlayer().setGold(0);
 
         controller.getShopItems().setDamagePotionLimit(0);
+        controller.getShopItems().setHintLimit(0);
+        controller.getShopItems().setShieldLimit(0);
         controller.getMainFrame().getBtnDamagePotion().setVisible(false);
         controller.getMainFrame().getBtnShield().setVisible(false);
         controller.getMainFrame().getBtnHint().setVisible(false);

--- a/src/view/SceneChanger.java
+++ b/src/view/SceneChanger.java
@@ -159,6 +159,8 @@ public class SceneChanger {
         controller.getMainFrame().getAnswerPanel().setVisible(false);
         controller.getMainFrame().getLabelsAndStatus().getLblLevel().setVisible(false);
         controller.getMainFrame().getPortalCreator().getLblPortal().setVisible(true);
+        controller.calculateGrade();
+        controller.getMainFrame().getMainMenu().getPnlHighscore().updateHighscoreList(controller.getHighscoreList().getHighscoreData());
     }
 
     /**
@@ -196,11 +198,7 @@ public class SceneChanger {
         controller.getMainFrame().getBtnShield().setVisible(false);
         controller.getMainFrame().getBtnHint().setVisible(false);
         controller.calculateGrade();
-
-        String name = controller.getPlayer().getName() + " - ";
-        String grade = controller.getCounter().getGrade() + " - ";
-        String amount = String.valueOf(controller.getCounter().getAnsweredAmount()) + "/70";
-        controller.getHighscoreList().addHighscore(name + grade + amount);
+        controller.getMainFrame().getMainMenu().getPnlHighscore().updateHighscoreList(controller.getHighscoreList().getHighscoreData());
     }
 
     /**
@@ -269,11 +267,6 @@ public class SceneChanger {
                 }
             }
         }
-        controller.calculateGrade();
-        String name = controller.getPlayer().getName() + " - ";
-        String grade = controller.getCounter().getGrade() + " - ";
-        String amount = String.valueOf(controller.getCounter().getAnsweredAmount()) + "/70";
-        controller.getHighscoreList().addHighscore(name + grade + amount);
     }
 
     /**

--- a/src/view/panels/FinalScenePanel.java
+++ b/src/view/panels/FinalScenePanel.java
@@ -1,5 +1,6 @@
 package view.panels;
 
+import controller.GameLogic;
 import controller.ImageResizer;
 import view.MainFrame;
 import controller.handlersAndActions.ActionHandler;
@@ -14,21 +15,24 @@ import java.awt.*;
 public class FinalScenePanel {
     private MainFrame mainFrame;
     private ActionHandler actionHandler;
+    private GameLogic controller;
 
     private JPanel pnlFinalScene;
     private JPanel pnlButtons;
 
     private JButton btnReturn;
     private JButton btnExit;
+    private JLabel lblScore;
 
     /**
      * Constructor
      * @param mainFrame Mainframe-object to set own MainFrame-object
      * @param actionHandler ActionHandler-object to set own ActionHandler-object
      */
-    public FinalScenePanel(MainFrame mainFrame, ActionHandler actionHandler) {
+    public FinalScenePanel(MainFrame mainFrame, ActionHandler actionHandler, GameLogic controller) {
         this.mainFrame = mainFrame;
         this.actionHandler = actionHandler;
+        this.controller = controller;
 
         createFinalScene();
     }
@@ -51,9 +55,14 @@ public class FinalScenePanel {
         lblFinaleName.setBounds(0, 0, 1350, 100);
         lblFinaleName.setForeground(Color.BLACK);
 
+        lblScore = new JLabel("TEST", JLabel.CENTER);
+        lblScore.setFont(new Font("Permanent Marker", Font.ITALIC, 60));
+        lblScore.setBounds(0, 70, 1350, 100);
+
         createButtons();
 
         pnlFinalScene.add(lblFinaleName);
+        pnlFinalScene.add(lblScore);
         pnlFinalScene.add(lblBg);
 
         mainFrame.add(pnlFinalScene);
@@ -111,6 +120,20 @@ public class FinalScenePanel {
 
         btnReturn.setActionCommand("returnMenu");
         btnExit.setActionCommand("exitGame");
+    }
+
+    /**
+     * Sets the score label attributes.
+     */
+    public void scoreAttributes() {
+        if(controller.isPassed()) {
+            lblScore.setForeground(Color.GREEN);
+        }
+        else if(!controller.isPassed()) {
+            lblScore.setForeground(Color.RED);
+        }
+        lblScore.setText("Grade: " + controller.getFinalGrade());
+        lblScore.setVisible(true);
     }
 
     /**


### PR DESCRIPTION
- Player can now only use consumables while in combat.

- Player will get a message if they try to use a consumable while not engaged in combat.

- Now displays the grade at the final scene.

- Now resets the grade when the player returns to the main menu.

- Changed the way the grades were added to the final to be more efficient now with less code.

- Fixed a bug where the door icon took focus over the help icon.

- Fixed a bug where the highscore did not update the JList after calculating.